### PR TITLE
marker export fix

### DIFF
--- a/io_export_md3_srb2.py
+++ b/io_export_md3_srb2.py
@@ -100,9 +100,11 @@ class md3Vert:
 
 	def Save(self, file):
 		tmpData = [0] * 4
-		tmpData[0] = int(self.xyz[0] * MD3_XYZ_SCALE)
-		tmpData[1] = int(self.xyz[1] * MD3_XYZ_SCALE)
-		tmpData[2] = int(self.xyz[2] * MD3_XYZ_SCALE)
+		for x in range(3):
+			if math.isnan(self.xyz[x]):
+				tmpData[x] = 0
+			else:
+				tmpData[x] = int(self.xyz[x] * MD3_XYZ_SCALE)
 		tmpData[3] = self.normal
 		data = struct.pack(self.binaryFormat, *tmpData)
 		file.write(data)
@@ -466,7 +468,11 @@ def save_md3(settings):###################### MAIN BODY
 
   ## Get and sort markers
   unsortedMarkers = bpy.context.scene.timeline_markers.values()
-  markers = sorted(unsortedMarkers, key=lambda x: x.frame)
+  filteredMarkers = []
+  for x in range(len(unsortedMarkers)):
+    if (unsortedMarkers[x].frame >= bpy.context.scene.frame_start) and (unsortedMarkers[x].frame <= bpy.context.scene.frame_end):
+      filteredMarkers.append(unsortedMarkers[x])
+  markers = sorted(filteredMarkers, key=lambda x: x.frame)
 
   for obj in selobjects:
     if obj.type == 'MESH':


### PR DESCRIPTION
Allows markers to be exported properly even if there are multiple preceding the ones being exported. Basically ignores any markers outside of the selected export frames to accomplish this.  Also includes a small fix for an issue I ran into where sometimes vertices would somehow be exported with NaN values, (possibly after being shrunk by bones). Not sure if this occurs in this version, but it can be ignored if not needed.